### PR TITLE
use long options

### DIFF
--- a/jdk7-alpine/Dockerfile
+++ b/jdk7-alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jdk7/Dockerfile
+++ b/jdk7/Dockerfile
@@ -7,17 +7,17 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -r "${GNUPGHOME}" \
+	&& rm --recursive "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \

--- a/jdk8-alpine/Dockerfile
+++ b/jdk8-alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -7,17 +7,17 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -r "${GNUPGHOME}" \
+	&& rm --recursive "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \

--- a/jdk9/Dockerfile
+++ b/jdk9/Dockerfile
@@ -7,24 +7,24 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Installing build dependencies" \
 	&& apt-get update \
-	&& apt-get update && apt-get install -y --no-install-recommends \
+	&& apt-get update && apt-get install --yes --no-install-recommends \
 		dirmngr \
 		gnupg \
-	&& rm -r /var/lib/apt/lists/* \
+	&& rm --recursive /var/lib/apt/lists/* \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -rf "${GNUPGHOME}" \
+	&& rm --recursive --force "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \
@@ -34,9 +34,9 @@ RUN set -eu \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& echo $(apt-mark showauto) \
-	&& apt-get remove -y --purge \
+	&& apt-get remove --yes --purge \
 		dirmngr \
 		gnupg \
-	&& apt-get autoremove -y --purge \
+	&& apt-get autoremove --yes --purge \
 	\
 	&& groovy --version

--- a/jre7-alpine/Dockerfile
+++ b/jre7-alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jre7/Dockerfile
+++ b/jre7/Dockerfile
@@ -7,17 +7,17 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -r "${GNUPGHOME}" \
+	&& rm --recursive "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jre8/Dockerfile
+++ b/jre8/Dockerfile
@@ -7,17 +7,17 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -r "${GNUPGHOME}" \
+	&& rm --recursive "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \

--- a/jre9/Dockerfile
+++ b/jre9/Dockerfile
@@ -7,24 +7,24 @@ ENV GROOVY_HOME /opt/groovy
 ENV PATH "${GROOVY_HOME}/bin:${PATH}"
 
 ENV GROOVY_VERSION 2.4.9
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Groovy" \
-	&& wget -nv -O groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+	&& wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
 	\
 	&& echo "Installing build dependencies" \
 	&& apt-get update \
-	&& apt-get update && apt-get install -y --no-install-recommends \
+	&& apt-get update && apt-get install --yes --no-install-recommends \
 		dirmngr \
 		gnupg \
-	&& rm -r /var/lib/apt/lists/* \
+	&& rm --recursive /var/lib/apt/lists/* \
 	\
 	&& echo "Checking download signature" \
-	&& wget -nv -O groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+	&& wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "0x41321490758AAD6F" "0x825C06C827AF6B66" "0x6A65176A0FB1CD0B" \
 	&& gpg --batch --verify groovy.zip.asc groovy.zip \
-	&& rm -rf "${GNUPGHOME}" \
+	&& rm --recursive --force "${GNUPGHOME}" \
 	&& rm groovy.zip.asc \
 	\
 	&& echo "Installing Groovy" \
@@ -34,9 +34,9 @@ RUN set -eu \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& echo $(apt-mark showauto) \
-	&& apt-get remove -y --purge \
+	&& apt-get remove --yes --purge \
 		 dirmngr \
 		 gnupg \
-	&& apt-get autoremove -y --purge \
+	&& apt-get autoremove --yes --purge \
 	\
 	&& groovy --version

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -eu
+set -o errexit -o nounset
 
 image=$1
 expectedGroovyVersion=$2
 
-version=$(docker run --rm -v "${PWD}:/scripts" -w "/scripts" "${image}" groovy printVersion.groovy)
+version=$(docker run --rm --volume "${PWD}:/scripts" --workdir "/scripts" "${image}" groovy printVersion.groovy)
 if [ "${version}" != "${expectedGroovyVersion}" ]; then
     echo "version '${version}' does not match expected version '${expectedGroovyVersion}'"
     exit 1


### PR DESCRIPTION
Using long options is more readable than short options. Short options are good for running interactive commands, but long options are better for scripts.