### PR TITLE
remove workaround for GROOVY-7906

### DIFF
--- a/jdk7-alpine/Dockerfile
+++ b/jdk7-alpine/Dockerfile
@@ -6,10 +6,6 @@ ENV GROOVY_HOME /opt/groovy
 ENV GROOVY_VERSION 2.4.13
 
 RUN set -o errexit -o nounset \
-	&& echo "Installing dependencies" \
-	&& apk add --no-cache \
-		bash \
-	\
 	&& echo "Installing build dependencies" \
 	&& apk add --no-cache --virtual .build-deps \
 		ca-certificates \
@@ -63,15 +59,6 @@ RUN set -o errexit -o nounset \
 	&& ln -s "${GROOVY_HOME}/bin/groovydoc" /usr/bin/groovydoc \
 	&& ln -s "${GROOVY_HOME}/bin/groovysh" /usr/bin/groovysh \
 	&& ln -s "${GROOVY_HOME}/bin/java2groovy" /usr/bin/java2groovy \
-	\
-	&& echo "Applying workaround for https://issues.apache.org/jira/browse/GROOVY-7906" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/grape" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovy" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyConsole" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovydoc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovysh" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/java2groovy" \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& apk del .build-deps \

--- a/jdk8-alpine/Dockerfile
+++ b/jdk8-alpine/Dockerfile
@@ -6,10 +6,6 @@ ENV GROOVY_HOME /opt/groovy
 ENV GROOVY_VERSION 2.4.13
 
 RUN set -o errexit -o nounset \
-	&& echo "Installing dependencies" \
-	&& apk add --no-cache \
-		bash \
-	\
 	&& echo "Installing build dependencies" \
 	&& apk add --no-cache --virtual .build-deps \
 		ca-certificates \
@@ -63,15 +59,6 @@ RUN set -o errexit -o nounset \
 	&& ln -s "${GROOVY_HOME}/bin/groovydoc" /usr/bin/groovydoc \
 	&& ln -s "${GROOVY_HOME}/bin/groovysh" /usr/bin/groovysh \
 	&& ln -s "${GROOVY_HOME}/bin/java2groovy" /usr/bin/java2groovy \
-	\
-	&& echo "Applying workaround for https://issues.apache.org/jira/browse/GROOVY-7906" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/grape" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovy" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyConsole" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovydoc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovysh" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/java2groovy" \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& apk del .build-deps \

--- a/jre7-alpine/Dockerfile
+++ b/jre7-alpine/Dockerfile
@@ -6,10 +6,6 @@ ENV GROOVY_HOME /opt/groovy
 
 ENV GROOVY_VERSION 2.4.13
 RUN set -o errexit -o nounset \
-	&& echo "Installing dependencies" \
-	&& apk add --no-cache \
-		bash \
-	\
 	&& echo "Installing build dependencies" \
 	&& apk add --no-cache --virtual .build-deps \
 		ca-certificates \
@@ -63,15 +59,6 @@ RUN set -o errexit -o nounset \
 	&& ln -s "${GROOVY_HOME}/bin/groovydoc" /usr/bin/groovydoc \
 	&& ln -s "${GROOVY_HOME}/bin/groovysh" /usr/bin/groovysh \
 	&& ln -s "${GROOVY_HOME}/bin/java2groovy" /usr/bin/java2groovy \
-	\
-	&& echo "Applying workaround for https://issues.apache.org/jira/browse/GROOVY-7906" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/grape" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovy" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyConsole" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovydoc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovysh" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/java2groovy" \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& apk del .build-deps \

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -6,10 +6,6 @@ ENV GROOVY_HOME /opt/groovy
 ENV GROOVY_VERSION 2.4.13
 
 RUN set -o errexit -o nounset \
-	&& echo "Installing dependencies" \
-	&& apk add --no-cache \
-		bash \
-	\
 	&& echo "Installing build dependencies" \
 	&& apk add --no-cache --virtual .build-deps \
 		ca-certificates \
@@ -63,15 +59,6 @@ RUN set -o errexit -o nounset \
 	&& ln -s "${GROOVY_HOME}/bin/groovydoc" /usr/bin/groovydoc \
 	&& ln -s "${GROOVY_HOME}/bin/groovysh" /usr/bin/groovysh \
 	&& ln -s "${GROOVY_HOME}/bin/java2groovy" /usr/bin/java2groovy \
-	\
-	&& echo "Applying workaround for https://issues.apache.org/jira/browse/GROOVY-7906" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/grape" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovy" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovyConsole" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovydoc" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/groovysh" \
-	&& sed -i "s|#!/bin/sh|#!/bin/bash|" "${GROOVY_HOME}/bin/java2groovy" \
 	\
 	&& echo "Cleaning up build dependencies" \
 	&& apk del .build-deps \


### PR DESCRIPTION
This has been fixed by [042dbdb3f74a238a09768676f03ea05dcce95606](https://github.com/apache/groovy/commit/042dbdb3f74a238a09768676f03ea05dcce95606) and [28d2f6a5f34f44f524ffea0e44be70c3c6a5c24e](https://github.com/apache/groovy/commit/28d2f6a5f34f44f524ffea0e44be70c3c6a5c24e).