### PR TITLE
Fix "gpg" usage to include "--batch"

### DIFF
--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -31,19 +31,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -31,12 +31,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jdk7-alpine/Dockerfile
+++ b/jdk7-alpine/Dockerfile
@@ -28,12 +28,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jdk7-alpine/Dockerfile
+++ b/jdk7-alpine/Dockerfile
@@ -28,19 +28,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget -qO groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm -rf "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jdk7/Dockerfile
+++ b/jdk7/Dockerfile
@@ -24,19 +24,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jdk7/Dockerfile
+++ b/jdk7/Dockerfile
@@ -24,12 +24,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jdk8-alpine/Dockerfile
+++ b/jdk8-alpine/Dockerfile
@@ -28,12 +28,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jdk8-alpine/Dockerfile
+++ b/jdk8-alpine/Dockerfile
@@ -28,19 +28,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget -qO groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm -rf "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -24,19 +24,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -24,12 +24,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jre11/Dockerfile
+++ b/jre11/Dockerfile
@@ -31,19 +31,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jre11/Dockerfile
+++ b/jre11/Dockerfile
@@ -31,12 +31,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jre7-alpine/Dockerfile
+++ b/jre7-alpine/Dockerfile
@@ -28,12 +28,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jre7-alpine/Dockerfile
+++ b/jre7-alpine/Dockerfile
@@ -28,19 +28,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget -qO groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm -rf "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jre7/Dockerfile
+++ b/jre7/Dockerfile
@@ -24,19 +24,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jre7/Dockerfile
+++ b/jre7/Dockerfile
@@ -24,12 +24,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -28,12 +28,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -28,19 +28,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget -qO groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm -rf "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jre8/Dockerfile
+++ b/jre8/Dockerfile
@@ -24,19 +24,19 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --no-tty --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \
     \
     && echo "Checking download signature" \
     && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
-    && gpg --batch --verify groovy.zip.asc groovy.zip \
+    && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \
     \

--- a/jre8/Dockerfile
+++ b/jre8/Dockerfile
@@ -24,12 +24,12 @@ RUN set -o errexit -o nounset \
             "pgp.mit.edu" \
         ; do \
             echo "  Trying ${server}"; \
-            if gpg --batch --no-tty --keyserver "${server}" --recv-keys "${key}"; then \
+            if gpg --batch --keyserver "${server}" --recv-keys "${key}"; then \
                 break; \
             fi; \
         done; \
     done; \
-    if [ $(gpg --list-keys | grep -c "pub ") -ne 5 ]; then \
+    if [ $(gpg --batch --list-keys | grep -c "pub ") -ne 5 ]; then \
         echo "ERROR: Failed to fetch GPG keys" >&2; \
         exit 1; \
     fi \


### PR DESCRIPTION
See https://bugs.debian.org/913614, especially:

> PS i do encourage everyone who is automating the use of gpg to use --batch everywhere, as this forces GnuPG into a mode that is expected to be used for automation (its "API", for lack of a better term, as opposed to its "UI", which is its normal non-batch mode).

Fixes https://github.com/groovy/docker-groovy/issues/41
Refs https://github.com/docker-library/official-images/issues/5082

See also https://github.com/docker-library/busybox/pull/55 and linked issues/PRs.