### PR TITLE
Replace dist with archive URL

### DIFF
--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \

--- a/jdk14/Dockerfile
+++ b/jdk14/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \

--- a/jre11/Dockerfile
+++ b/jre11/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \

--- a/jre14/Dockerfile
+++ b/jre14/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \

--- a/jre8/Dockerfile
+++ b/jre8/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 ENV GROOVY_VERSION 3.0.2
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
-    && wget --no-verbose --output-document=groovy.zip "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
+    && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \
     \
     && echo "Importing keys listed in http://www.apache.org/dist/groovy/KEYS from key server" \
     && export GNUPGHOME="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -o errexit -o nounset \
     fi \
     \
     && echo "Checking download signature" \
-    && wget --no-verbose --output-document=groovy.zip.asc "https://dist.apache.org/repos/dist/release/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
+    && wget --no-verbose --output-document=groovy.zip.asc "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip.asc" \
     && gpg --batch --no-tty --verify groovy.zip.asc groovy.zip \
     && rm --recursive --force "${GNUPGHOME}" \
     && rm groovy.zip.asc \


### PR DESCRIPTION
dist.apache.org is deprecated (replaced with downloads.apache.org), but these URLs only contain the latest release. If a new update comes out and we need to rebuild images for a security issue or whatever, the docker build will fail.

So switching URLs to archive.apache.org that contains all releases.