### PR TITLE
Use numeric rather than string USER

### DIFF
--- a/jdk11-alpine/Dockerfile
+++ b/jdk11-alpine/Dockerfile
@@ -61,7 +61,7 @@ RUN set -o errexit -o nounset \
     && echo "Editing startGroovy to include java.xml.bind module" \
     && sed --in-place 's|startGroovy ( ) {|startGroovy ( ) {\n    JAVA_OPTS="$JAVA_OPTS --add-modules=ALL-SYSTEM"|' "${GROOVY_HOME}/bin/startGroovy"
 
-USER groovy
+USER 1000:1000
 
 RUN set -o errexit -o nounset \
     && echo "Testing Groovy installation" \

--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -63,7 +63,7 @@ RUN set -o errexit -o nounset \
     && echo "Editing startGroovy to include java.xml.bind module" \
     && sed --in-place 's|startGroovy ( ) {|startGroovy ( ) {\n    JAVA_OPTS="$JAVA_OPTS --add-modules=ALL-SYSTEM"|' "${GROOVY_HOME}/bin/startGroovy"
 
-USER groovy
+USER 1000:1000
 
 RUN set -o errexit -o nounset \
     && echo "Testing Groovy installation" \

--- a/jdk17-alpine/Dockerfile
+++ b/jdk17-alpine/Dockerfile
@@ -61,7 +61,7 @@ RUN set -o errexit -o nounset \
     && echo "Editing startGroovy to include java.xml.bind module" \
     && sed --in-place 's|startGroovy ( ) {|startGroovy ( ) {\n    JAVA_OPTS="$JAVA_OPTS --add-modules=ALL-SYSTEM"|' "${GROOVY_HOME}/bin/startGroovy"
 
-USER groovy
+USER 1000:1000
 
 RUN set -o errexit -o nounset \
     && echo "Testing Groovy installation" \

--- a/jdk17/Dockerfile
+++ b/jdk17/Dockerfile
@@ -63,7 +63,7 @@ RUN set -o errexit -o nounset \
     && echo "Editing startGroovy to include java.xml.bind module" \
     && sed --in-place 's|startGroovy ( ) {|startGroovy ( ) {\n    JAVA_OPTS="$JAVA_OPTS --add-modules=ALL-SYSTEM"|' "${GROOVY_HOME}/bin/startGroovy"
 
-USER groovy
+USER 1000:1000
 
 RUN set -o errexit -o nounset \
     && echo "Testing Groovy installation" \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -60,7 +60,7 @@ RUN set -o errexit -o nounset \
     && ln --symbolic "${GROOVY_HOME}/bin/groovysh" /usr/bin/groovysh \
     && ln --symbolic "${GROOVY_HOME}/bin/java2groovy" /usr/bin/java2groovy
 
-USER groovy
+USER 1000:1000
 
 RUN set -o errexit -o nounset \
     && echo "Testing Groovy installation" \


### PR DESCRIPTION
Kubernetes defaults to the image metadata when a `runAsUser` is not specified. As noted in their documentation.

```
$ kubectl explain pod.spec.securityContext.runAsUser
KIND:     Pod
VERSION:  v1

FIELD:    runAsUser <integer>

DESCRIPTION:
     The UID to run the entrypoint of the container process. Defaults to user
     specified in image metadata if unspecified. May also be set in
     SecurityContext. If set in both SecurityContext and PodSecurityContext, the
     value specified in SecurityContext takes precedence for that container.
     Note that this field cannot be set when spec.os.name is windows.
```

However, when the metadata is a string, like `USER groovy`, you get an error like the below when combined with `runAsNonRoot: true`,
```
Error: container has runAsNonRoot and image has non-numeric user (idsvr), cannot verify user is non-root
```

We should change the `USER` statements to be numeric rather than strings, as a better default for Kubernetes.