### PR TITLE
Replace legacy style env vars

### DIFF
--- a/jdk11-alpine/Dockerfile
+++ b/jdk11-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11-jdk-alpine
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -19,7 +19,7 @@ VOLUME /home/groovy/.groovy/grapes
 
 WORKDIR /home/groovy
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Installing build dependencies" \
     && apk add --no-cache --virtual .build-deps \

--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11-jdk-jammy
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -29,7 +29,7 @@ RUN set -o errexit -o nounset \
         wget \
     && rm --recursive --force /var/lib/apt/lists/*
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
     && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \

--- a/jdk17-alpine/Dockerfile
+++ b/jdk17-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk-alpine
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -19,7 +19,7 @@ VOLUME /home/groovy/.groovy/grapes
 
 WORKDIR /home/groovy
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Installing build dependencies" \
     && apk add --no-cache --virtual .build-deps \

--- a/jdk17/Dockerfile
+++ b/jdk17/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk-jammy
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -29,7 +29,7 @@ RUN set -o errexit -o nounset \
         wget \
     && rm --recursive --force /var/lib/apt/lists/*
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
     && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \

--- a/jdk21-alpine/Dockerfile
+++ b/jdk21-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jdk-alpine
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -19,7 +19,7 @@ VOLUME /home/groovy/.groovy/grapes
 
 WORKDIR /home/groovy
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Installing build dependencies" \
     && apk add --no-cache --virtual .build-deps \

--- a/jdk21/Dockerfile
+++ b/jdk21/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jdk-jammy
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -29,7 +29,7 @@ RUN set -o errexit -o nounset \
         wget \
     && rm --recursive --force /var/lib/apt/lists/*
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
     && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:8-jdk-jammy
 
 CMD ["groovysh"]
 
-ENV GROOVY_HOME /opt/groovy
+ENV GROOVY_HOME=/opt/groovy
 
 RUN set -o errexit -o nounset \
     && echo "Adding groovy user and group" \
@@ -29,7 +29,7 @@ RUN set -o errexit -o nounset \
         wget \
     && rm --recursive --force /var/lib/apt/lists/*
 
-ENV GROOVY_VERSION 4.0.22
+ENV GROOVY_VERSION=4.0.22
 RUN set -o errexit -o nounset \
     && echo "Downloading Groovy" \
     && wget --no-verbose --output-document=groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" \

--- a/update.ps1
+++ b/update.ps1
@@ -3,6 +3,6 @@ $groovyVersion = $(((Invoke-WebRequest "https://api.github.com/repos/apache/groo
 Write-Host "Updating to Groovy $groovyVersion"
 
 dir -Recurse -Filter Dockerfile | ForEach-Object {
-    (Get-Content -Path $_.FullName) -replace "ENV GROOVY_VERSION .+", "ENV GROOVY_VERSION ${groovyVersion}" | Set-Content $_.FullName
+    (Get-Content -Path $_.FullName) -replace "ENV GROOVY_VERSION=.+", "ENV GROOVY_VERSION=${groovyVersion}" | Set-Content $_.FullName
 }
 (Get-Content -Path .github/workflows/ci.yaml) -replace "expectedGroovyVersion: .+", "expectedGroovyVersion: ${groovyVersion}" | Set-Content .github/workflows/ci.yaml

--- a/update.sh
+++ b/update.sh
@@ -4,5 +4,5 @@ set -o errexit -o nounset -o pipefail
 groovyVersion=$(curl -s 'https://api.github.com/repos/apache/groovy/tags' | grep -Eo 'GROOVY_4.[0-9]{1,2}.[0-9]{1,2}' | head -n 1 | sed -e 's/GROOVY_//' -e 's/_/./g')
 echo "Updating to Groovy $groovyVersion"
 
-sed --regexp-extended --in-place "s/ENV GROOVY_VERSION .+/ENV GROOVY_VERSION ${groovyVersion}/" ./*/Dockerfile
+sed --regexp-extended --in-place "s/ENV GROOVY_VERSION=.+/ENV GROOVY_VERSION=${groovyVersion}/" ./*/Dockerfile
 sed --regexp-extended --in-place "s/expectedGroovyVersion: .+$/expectedGroovyVersion: ${groovyVersion}/" .github/workflows/ci.yaml


### PR DESCRIPTION
Fixes violations of this build check: https://docs.docker.com/reference/build-checks/legacy-key-value-format/