### PR TITLE
Optimize generate-stackbrew-library.sh by replacing sed in loop with parameter expansion

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -84,8 +84,7 @@ eval "directories=( $directories )"
 
 
 for dir in "${directories[@]}"; do
-	# shellcheck disable=SC2001
-	dir="$(echo "$dir" | sed -e 's/[[:space:]]*$//')"
+	dir="${dir%"${dir##*[![:space:]]}"}"
 	if [ ! -d "$dir" ]; then
 		# skip directory that doesn't exist in this branch
 		continue


### PR DESCRIPTION
Replaced the inefficient `sed` call inside the loop with native shell parameter expansion `${dir%"${dir##*[![:space:]]}"}` to remove trailing whitespace. This avoids forking a new process for every iteration, improving performance and maintainability. Also removed the now unnecessary shellcheck disable comment.